### PR TITLE
Resources

### DIFF
--- a/app/Enums/Resource/ResourceTypes.php
+++ b/app/Enums/Resource/ResourceTypes.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Enums\Resource;
+
+enum ResourceTypes: string
+{
+	/**
+	 * This type should be used to attach some project from ACC to a internal project.
+	 */
+	case accProject = 'ACC_PROJECT';
+
+	/**
+	 * This type of resource should be used when the resource is a BIM Model, regardless if it comes from the OSS provided by the APS or from an ACC user's account.
+	 */
+	case model = 'MODEL';
+
+	/**
+	 * This type of resource should be used when the reource is the image to use as the cover of its resourceable.
+	 */
+	case cover = 'COVER';
+
+	/**
+	 * This type of resource should be used when the reource is a regular image for the resourceable.
+	 */
+	case image = 'IMAGE';
+
+	/**
+	 * This type of resource should be used for any other kind of file not listaed her.
+	 */
+	case file = 'FILE';
+}

--- a/app/Models/Authorization.php
+++ b/app/Models/Authorization.php
@@ -4,10 +4,12 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Authorization extends Model
 {
 	use HasFactory;
+	use SoftDeletes;
 
 	protected $fillable = [
 		'provider',

--- a/app/Models/Authorization.php
+++ b/app/Models/Authorization.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Authorization extends Model
@@ -20,4 +21,14 @@ class Authorization extends Model
 		'authorizable_class',
 		'authorizable_id'
 	];
+
+	/**
+	 * Get all of the resources for the Authorization
+	 *
+	 * @return \Illuminate\Database\Eloquent\Relations\HasMany
+	 */
+	public function resources(): HasMany
+	{
+		return $this->hasMany(related: Resource::class);
+	}
 }

--- a/app/Models/Resource.php
+++ b/app/Models/Resource.php
@@ -4,16 +4,18 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Resource extends Model
 {
-    use HasFactory;
+	use HasFactory;
+	use SoftDeletes;
 
-		protected $fillable = [
-			'authorization_id',
-			'path_in_source',
-			'id_in_source',
-			'alias',
-			'type'
-		];
+	protected $fillable = [
+		'authorization_id',
+		'path_in_source',
+		'id_in_source',
+		'alias',
+		'type'
+	];
 }

--- a/app/Models/Resource.php
+++ b/app/Models/Resource.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Resource extends Model
@@ -18,4 +19,14 @@ class Resource extends Model
 		'alias',
 		'type'
 	];
+
+	/**
+	 * Get the authorization that owns the Resource
+	 *
+	 * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+	 */
+	public function authorization(): BelongsTo
+	{
+		return $this->belongsTo(related: Authorization::class);
+	}
 }

--- a/app/Models/Resource.php
+++ b/app/Models/Resource.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Resource extends Model
+{
+    use HasFactory;
+
+		protected $fillable = [
+			'authorization_id',
+			'path_in_source',
+			'id_in_source',
+			'alias',
+			'type'
+		];
+}

--- a/database/migrations/2024_03_20_174342_create_authorizations_table.php
+++ b/database/migrations/2024_03_20_174342_create_authorizations_table.php
@@ -13,7 +13,7 @@ return new class extends Migration
 	public function up(): void
 	{
 		Schema::create('authorizations', function (Blueprint $table) {
-			$table->uuid('id');
+			$table->uuid('id')->primary();
 			$table->enum('provider', array_column(ThirdPartyProviders::cases(), 'value'));
 			$table->string('access_token');
 			$table->string('refresh_token');
@@ -22,6 +22,7 @@ return new class extends Migration
 			$table->string('authorizable_class', 50);
 			$table->string('authorizable_id', 50);
 			$table->timestamps();
+			$table->softDeletes();
 		});
 	}
 

--- a/database/migrations/2024_03_20_194115_create_resources_table.php
+++ b/database/migrations/2024_03_20_194115_create_resources_table.php
@@ -15,13 +15,14 @@ return new class extends Migration
 	public function up(): void
 	{
 		Schema::create(table: 'resources', callback: function (Blueprint $table) {
-			$table->uuid(column: 'id');
-			$table->foreignId(column: 'authorization_id')->nullable()->constrained();
+			$table->uuid(column: 'id')->primary();
+			$table->foreignUuid(column: 'authorization_id')->nullable()->constrained();
 			$table->string(column: 'path_in_source')->nullable();
 			$table->string(column: 'id_in_source')->nullable();
 			$table->string(column: 'alias', length: 250);
 			$table->enum(column: 'type', allowed: array_column(ResourceTypes::cases(), 'value'));
 			$table->timestamps();
+			$table->softDeletes();
 		});
 	}
 

--- a/database/migrations/2024_03_20_194115_create_resources_table.php
+++ b/database/migrations/2024_03_20_194115_create_resources_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use App\Enums\Resource\ResourceTypes;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+use function PHPUnit\Framework\callback;
+
+return new class extends Migration
+{
+	/**
+	 * Run the migrations.
+	 */
+	public function up(): void
+	{
+		Schema::create(table: 'resources', callback: function (Blueprint $table) {
+			$table->uuid(column: 'id');
+			$table->foreignId(column: 'authorization_id')->nullable()->constrained();
+			$table->string(column: 'path_in_source')->nullable();
+			$table->string(column: 'id_in_source')->nullable();
+			$table->string(column: 'alias', length: 250);
+			$table->enum(column: 'type', allowed: array_column(ResourceTypes::cases(), 'value'));
+			$table->timestamps();
+		});
+	}
+
+	/**
+	 * Reverse the migrations.
+	 */
+	public function down(): void
+	{
+		Schema::dropIfExists(table: 'resources');
+	}
+};


### PR DESCRIPTION
This changes define the `Resource` model with the `enums` that should be used for filling and constraining the corresponding entity's fields. Additionally, the relationship between the `Authorization` entity and the `Resource` one is defined and the corresponding migrations are fixed in order to properly work with `uuid`s instead of `id`.