### PR TITLE
Custom guard for the Auth Facade

### DIFF
--- a/app/Http/Middleware/Authentication/SessionInAuthenticator.php
+++ b/app/Http/Middleware/Authentication/SessionInAuthenticator.php
@@ -2,11 +2,9 @@
 
 namespace App\Http\Middleware\Authentication;
 
-use App\Models\User;
-use Barryvdh\Debugbar\Facades\Debugbar;
 use Closure;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Auth;
 use Symfony\Component\HttpFoundation\Response;
 
 class SessionInAuthenticator
@@ -18,60 +16,11 @@ class SessionInAuthenticator
 	 */
 	public function handle(Request $request, Closure $next): Response
 	{
-
-		$sessionCookieName = str_replace(search: '.', replace: '_', subject: env('AUTHENTICATOR_APP_COOKIE_FOR_SESSION'));
-
-		$sessionCookie = $request->cookie(key: $sessionCookieName);
-
-		if (is_null($sessionCookie)) {
-			return $this->redirectToAuthenticator($request->fullUrl());
+		if (!Auth::guard('authenticator')->check()) {
+			return $this->redirectToAuthenticator(redirectionBack: $request->fullUrl());
 		}
-
-		$user = $this->isValidSession(sessionToken: $sessionCookie);
-
-		if (is_null($user)) {
-			return $this->redirectToAuthenticator($request->fullUrl());
-		}
-
-		$request->session()->put(key: 'user', value: $user);
 
 		return $next($request);
-	}
-
-	private function isValidSession(string $sessionToken = null): \App\Models\User | null
-	{
-		Debugbar::debug($sessionToken);
-
-		$endpoint = env('AUTHENTICATOR_APP_URL') . env('AUTHENTICATOR_APP_SESSION_ENDPOINT');
-
-		$response = Http::withCookies(
-			cookies: [
-				env('AUTHENTICATOR_APP_COOKIE_FOR_SESSION') => $sessionToken
-			],
-			domain: '.sohersabim.test'
-		)->get(url: $endpoint);
-
-		if ($response->failed()) {
-			return null;
-		}
-
-		$responseJson = $response->json();
-
-		if (empty($responseJson)) {
-			return null;
-		}
-
-		$authenticatedUser = $responseJson['user'];
-
-		if (is_null($authenticatedUser)) {
-			return null;
-		}
-
-		$user = new User($authenticatedUser);
-		$user->id = $authenticatedUser['id'];
-
-		return $user;
-
 	}
 
 	private function redirectToAuthenticator(string $redirectionBack)

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -3,7 +3,10 @@
 namespace App\Providers;
 
 // use Illuminate\Support\Facades\Gate;
+use App\Source\Authentication\Application\ValidateSession;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
 
 class AuthServiceProvider extends ServiceProvider
 {
@@ -21,6 +24,16 @@ class AuthServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        Auth::viaRequest('authenticatorDriver', function (Request $request){
+
+					$sessionCookieName = str_replace(search: '.', replace: '_', subject: env('AUTHENTICATOR_APP_COOKIE_FOR_SESSION'));
+
+					$sessionCookie = $request->cookie(key: $sessionCookieName);
+
+					return is_null($sessionCookie)
+						? null
+						: ValidateSession::isValidSession(sessionToken: $sessionCookie);
+
+				});
     }
 }

--- a/app/Source/Authentication/Application/ValidateSession.php
+++ b/app/Source/Authentication/Application/ValidateSession.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Source\Authentication\Application;
+
+use App\Models\User;
+use Illuminate\Support\Facades\Http;
+
+class ValidateSession {
+
+	public static function isValidSession(string $sessionToken = null): \App\Models\User | null
+	{
+
+		$endpoint = env('AUTHENTICATOR_APP_URL') . env('AUTHENTICATOR_APP_SESSION_ENDPOINT');
+
+		$response = Http::withCookies(
+			cookies: [
+				env('AUTHENTICATOR_APP_COOKIE_FOR_SESSION') => $sessionToken
+			],
+			domain: '.sohersabim.test'
+		)->get(url: $endpoint);
+
+		if ($response->failed()) {
+			return null;
+		}
+
+		$responseJson = $response->json();
+
+		if (empty($responseJson)) {
+			return null;
+		}
+
+		$authenticatedUser = $responseJson['user'];
+
+		if (is_null($authenticatedUser)) {
+			return null;
+		}
+
+		$user = new User($authenticatedUser);
+		$user->id = $authenticatedUser['id'];
+
+		return $user;
+
+	}
+
+}

--- a/config/auth.php
+++ b/config/auth.php
@@ -40,6 +40,10 @@ return [
             'driver' => 'session',
             'provider' => 'users',
         ],
+				'authenticator' => [
+					'driver' => 'authenticatorDriver',
+					'provider' => 'users'
+				]
     ],
 
     /*


### PR DESCRIPTION
Defining a custom guard for the Auth facade in order to organize the authentication against the AuthenticatorApp. This way, the user data is still accessible through that facade.